### PR TITLE
Correct Maven artifactId/name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>sethau.chatter</groupId>
-  <artifactId>chatter-test</artifactId>
+  <artifactId>Chatter</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>chatter-test</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>Chatter</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
-  <name>chatter-test</name>
+  <name>Chatter</name>
   <url>http://maven.apache.org</url>
   <build>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>


### PR DESCRIPTION
Accidentally left chatter-test as the Maven artifactId/name in pom.xml
